### PR TITLE
Improve overlap resolution

### DIFF
--- a/pygeosimplify/simplify/cylinder.py
+++ b/pygeosimplify/simplify/cylinder.py
@@ -9,24 +9,24 @@ class Cylinder:
     zmax: float
     is_barrel: bool
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Initialize a dictionary to keep track of the lock status of each attribute
         # Note that the lock is just an attribute and does not actually prevent the value from being changed
         self._locks = {"rmin": False, "rmax": False, "zmin": False, "zmax": False, "is_barrel": False}
 
-    def lock(self, attr):
+    def lock(self, attr: str) -> None:
         if attr in self._locks:
             self._locks[attr] = True
         else:
             raise AttributeError(f"No such attribute: {attr}")
 
-    def unlock(self, attr):
+    def unlock(self, attr: str) -> None:
         if attr in self._locks:
             self._locks[attr] = False
         else:
             raise AttributeError(f"No such attribute: {attr}")
 
-    def is_locked(self, attr):
+    def is_locked(self, attr: str) -> bool:
         if attr in self._locks:
             return self._locks[attr]
         else:

--- a/pygeosimplify/simplify/cylinder.py
+++ b/pygeosimplify/simplify/cylinder.py
@@ -9,6 +9,29 @@ class Cylinder:
     zmax: float
     is_barrel: bool
 
+    def __post_init__(self):
+        # Initialize a dictionary to keep track of the lock status of each attribute
+        # Note that the lock is just an attribute and does not actually prevent the value from being changed
+        self._locks = {"rmin": False, "rmax": False, "zmin": False, "zmax": False, "is_barrel": False}
+
+    def lock(self, attr):
+        if attr in self._locks:
+            self._locks[attr] = True
+        else:
+            raise AttributeError(f"No such attribute: {attr}")
+
+    def unlock(self, attr):
+        if attr in self._locks:
+            self._locks[attr] = False
+        else:
+            raise AttributeError(f"No such attribute: {attr}")
+
+    def is_locked(self, attr):
+        if attr in self._locks:
+            return self._locks[attr]
+        else:
+            raise AttributeError(f"No such attribute: {attr}")
+
 
 @dataclass
 class CylinderGroup:

--- a/pygeosimplify/simplify/detector.py
+++ b/pygeosimplify/simplify/detector.py
@@ -70,7 +70,7 @@ class SimplifiedDetector:
                     "diff": abs((endcap.zmin - self.min_dist) - barrel.zmax),
                     "locked": barrel.is_locked("zmax"),
                     "action": lambda barrel=barrel, endcap=endcap: (
-                        setattr(barrel, "zmax", endcap.zmin - self.min_dist),
+                        setattr(barrel, "zmax", endcap.zmin - self.min_dist),  # type: ignore[func-returns-value]
                         barrel.lock("zmax"),
                     ),
                 },
@@ -82,7 +82,7 @@ class SimplifiedDetector:
                     "diff": abs((barrel.rmin - self.min_dist) - endcap.rmax),
                     "locked": endcap.is_locked("rmax"),
                     "action": lambda barrel=barrel, endcap=endcap: (
-                        setattr(endcap, "rmax", barrel.rmin - self.min_dist),
+                        setattr(endcap, "rmax", barrel.rmin - self.min_dist),  # type: ignore[func-returns-value]
                         endcap.lock("rmax"),
                     ),
                 },
@@ -94,7 +94,7 @@ class SimplifiedDetector:
                     "diff": abs(endcap.rmin - (barrel.rmax + self.min_dist)),
                     "locked": endcap.is_locked("rmin"),
                     "action": lambda barrel=barrel, endcap=endcap: (
-                        setattr(endcap, "rmin", barrel.rmax + self.min_dist),
+                        setattr(endcap, "rmin", barrel.rmax + self.min_dist),  # type: ignore[func-returns-value]
                         endcap.lock("rmin"),
                     ),
                 },
@@ -105,10 +105,10 @@ class SimplifiedDetector:
 
             # Choose the option with the lowest difference in values
             if available_options:
-                best_option = min(available_options, key=lambda x: x["diff"])
+                best_option = min(available_options, key=lambda x: x["diff"])  # type: ignore[arg-type, return-value]
                 print(f"Choosing {best_option['name']} with diff {best_option['diff']}\n")
                 # Apply the best resolution option
-                best_option["action"]()
+                best_option["action"]()  # type: ignore[operator]
             else:
                 raise Exception(
                     f"{mt.FAIL} Overlap resolution between thinned layer {cyl_a_name} and layer {cyl_b_name} not"

--- a/pygeosimplify/simplify/detector.py
+++ b/pygeosimplify/simplify/detector.py
@@ -33,7 +33,10 @@ class SimplifiedDetector:
         if n_overlaps == 0:
             return
 
-        for overlap_pair in overlapping_layers:
+        while n_overlaps > 0:
+            # Take the first overlapping pair
+            overlap_pair = overlapping_layers[0]
+            # Take the cylinders from the overlapping pair
             cyl_a_name = overlap_pair[0]
             cyl_b_name = overlap_pair[1]
 
@@ -57,41 +60,69 @@ class SimplifiedDetector:
                 " resolve..."
             )
 
-            # Option A: Shorten the zmax of the barrel layer to the zmin of the endcap layer
-            new_barrel_zmax = endcap.zmin - self.min_dist
-            opt_A_diff = abs(new_barrel_zmax - barrel.zmax)
-            # Option B: Decrease rmax of endcap layer to rmin of barrel layer
-            new_endcap_rmax = barrel.rmin - self.min_dist
-            opt_B_diff = abs(new_endcap_rmax - endcap.rmax)
-            # Option C: Increase rmin of endcap to rmax of barrel layer
-            new_encap_rmin = barrel.rmax + self.min_dist
-            opt_C_diff = abs(endcap.rmin - new_encap_rmin)
+            # Calculate new values and their differences
+            options = [
+                {
+                    "name": (
+                        f"Option A: Shorten the zmax of the barrel layer ({barrel.zmax}) to the zmin of the endcap"
+                        f" layer ({endcap.zmin - self.min_dist})"
+                    ),
+                    "diff": abs((endcap.zmin - self.min_dist) - barrel.zmax),
+                    "locked": barrel.is_locked("zmax"),
+                    "action": lambda barrel=barrel, endcap=endcap: (
+                        setattr(barrel, "zmax", endcap.zmin - self.min_dist),
+                        barrel.lock("zmax"),
+                    ),
+                },
+                {
+                    "name": (
+                        f"Option B: Decrease rmax of endcap layer ({endcap.rmax}) to rmin of barrel layer"
+                        f" ({barrel.rmin - self.min_dist})"
+                    ),
+                    "diff": abs((barrel.rmin - self.min_dist) - endcap.rmax),
+                    "locked": endcap.is_locked("rmax"),
+                    "action": lambda barrel=barrel, endcap=endcap: (
+                        setattr(endcap, "rmax", barrel.rmin - self.min_dist),
+                        endcap.lock("rmax"),
+                    ),
+                },
+                {
+                    "name": (
+                        f"Option C: Increase rmin of endcap layer ({endcap.rmin}) to rmax of barrel layer"
+                        f" ({barrel.rmax + self.min_dist})"
+                    ),
+                    "diff": abs(endcap.rmin - (barrel.rmax + self.min_dist)),
+                    "locked": endcap.is_locked("rmin"),
+                    "action": lambda barrel=barrel, endcap=endcap: (
+                        setattr(endcap, "rmin", barrel.rmax + self.min_dist),
+                        endcap.lock("rmin"),
+                    ),
+                },
+            ]
 
-            # Use option with minimal change
-            if opt_A_diff < opt_B_diff and opt_A_diff < opt_C_diff:
-                print(f"{mt.BOLD} Setting barrel zmax from {barrel.zmax} to {new_barrel_zmax}")
-                barrel.zmax = new_barrel_zmax
-            elif opt_B_diff < opt_A_diff and opt_B_diff < opt_C_diff:
-                print(f"{mt.BOLD} Setting endcap rmax from {endcap.rmax} to {new_endcap_rmax}")
-                endcap.rmax = new_endcap_rmax
+            # Filter out locked options which have already been modified by previous overlap resolutions
+            available_options = [opt for opt in options if not opt["locked"]]
+
+            # Choose the option with the lowest difference in values
+            if available_options:
+                best_option = min(available_options, key=lambda x: x["diff"])
+                print(f"Choosing {best_option['name']} with diff {best_option['diff']}\n")
+                # Apply the best resolution option
+                best_option["action"]()
             else:
-                print(f"{mt.BOLD} Setting endcap rmin from {endcap.rmin} to {new_encap_rmin}")
-                endcap.rmin = new_encap_rmin
+                raise Exception(
+                    f"{mt.FAIL} Overlap resolution between thinned layer {cyl_a_name} and layer {cyl_b_name} not"
+                    " possible. All possible options are locked. Manual check required."
+                )
 
             # Update the thinned cylinder dictionary
             self.cylinders.thinned[cyl_a_name] = barrel if cyl_a.is_barrel else endcap
             self.cylinders.thinned[cyl_b_name] = barrel if cyl_b.is_barrel else endcap
 
-        # Check if overlaps have been resolved
-        n_overlaps, _ = self.check_overlaps(cyl_type="thinned", print_output=False)
+            # Check again for overlapping layers
+            n_overlaps, overlapping_layers = self.check_overlaps(cyl_type="thinned", print_output=False)
 
-        if n_overlaps > 0:
-            raise Exception(
-                f"{mt.FAIL} Overlap resolution of thinned cylinders failed. {n_overlaps} overlaps remain. This is not"
-                " supposed to happen."
-            )
-        else:
-            print(f"{mt.SUCCESS} Thinned cylinder overlaps resolved.")
+        print(f"{mt.SUCCESS} Thinned cylinder overlaps resolved.")
 
     def _symmetrize_cylinders(self, cyl_type: str = "thinned") -> dict[str, Cylinder]:
         # Get the dimensions for the requested cylinder type


### PR DESCRIPTION
This pull request improves the overlap resolution:

- overlaps are now re-checked after each overlap resolution process
- coordinates from modified layers are now locked such that they cannot be modified by subsequent overlap resolutions
- if the overlap resolution would modify a locked coordinate, the next best resolution attempt is performed