### PR TITLE
add a method to merge barrel layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ detector.add_layer(layer)
 
 # Process detector
 detector.process()
+detector.merge_barrel()
 
 # Save simplified detector to gdml file
 detector.save_to_gdml(cyl_type='processed', output_path='processed.gdml')

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ detector.add_layer(layer)
 
 # Process detector
 detector.process()
-detector.merge_barrel()
 
 # Save simplified detector to gdml file
 detector.save_to_gdml(cyl_type='processed', output_path='processed.gdml')

--- a/pygeosimplify/simplify/detector.py
+++ b/pygeosimplify/simplify/detector.py
@@ -160,8 +160,8 @@ class SimplifiedDetector:
                 # ignore barrel layers which are not continuous at z=0
                 if self.cylinders.processed[pos_cyl_name].zmin != 0 or self.cylinders.processed[neg_cyl_name].zmax != 0:
                     print(
-                        f"{mt.WARNING} Cannot merge barrel layer {merged_cyc_name}. "
-                        "Layer is not continuous at z=0. Ignoring!"
+                        f"{mt.WARNING} Barrel layer {merged_cyc_name} will not be merged. "
+                        "Layer is not continuous at z=0."
                     )
                     continue
 

--- a/pygeosimplify/simplify/detector.py
+++ b/pygeosimplify/simplify/detector.py
@@ -142,6 +142,34 @@ class SimplifiedDetector:
 
         return {**cyl_dict_pos_z, **cyl_dict_neg_z}
 
+    def _merge_barrel(self) -> None:
+        """
+        Produce a single barrel layer by merging its positive and negative halves.
+        """
+        if not self.processed:
+            raise Exception("Detector has not been processed yet. Process first with detector.process()")
+
+        # merge positve and negative halves of barrel layers
+        processed_cyl_names = [*self.cylinders.processed.keys()]
+        for each_cyl_name in processed_cyl_names:
+            if "_POS" in each_cyl_name and self.cylinders.processed[each_cyl_name].is_barrel:
+                pos_cyl_name = each_cyl_name
+                neg_cyl_name = each_cyl_name.replace("_POS", "_NEG")
+                merged_cyc_name = each_cyl_name.replace("_POS", "")
+
+                # ignore barrel layers which are not continuous at z=0
+                if self.cylinders.processed[pos_cyl_name].zmin != 0 or self.cylinders.processed[neg_cyl_name].zmax != 0:
+                    print(
+                        f"{mt.WARNING} Cannot merge barrel layer {merged_cyc_name}. "
+                        "Layer is not continuous at z=0. Ignoring!"
+                    )
+                    continue
+
+                self.cylinders.processed[pos_cyl_name].zmin = self.cylinders.processed[neg_cyl_name].zmin
+                self.cylinders.processed[merged_cyc_name] = self.cylinders.processed[pos_cyl_name]
+                del self.cylinders.processed[pos_cyl_name]
+                del self.cylinders.processed[neg_cyl_name]
+
     def add_layer(self, layer: GeoLayer) -> None:
         # Ensure that the layer does not already exist in the simplified detector
         if layer.idx in self.cylinders.thinned:
@@ -171,34 +199,8 @@ class SimplifiedDetector:
             min_dist=self.min_dist,
             envelope_width=self.envelope_width,
         )
-
-    def merge_barrel(self) -> None:
-        """
-        Produce a single barrel layer by merging its positive and negative halves.
-        """
-        if not self.processed:
-            raise Exception("Detector has not been processed yet. Process first with detector.process()")
-
-        # merge positve and negative halves of barrel layers
-        processed_cyl_names = [*self.cylinders.processed.keys()]
-        for each_cyl_name in processed_cyl_names:
-            if "_POS" in each_cyl_name and self.cylinders.processed[each_cyl_name].is_barrel:
-                pos_cyl_name = each_cyl_name
-                neg_cyl_name = each_cyl_name.replace("_POS", "_NEG")
-                merged_cyc_name = each_cyl_name.replace("_POS", "")
-
-                # ignore barrel layers which are not continuous at z=0
-                if self.cylinders.processed[pos_cyl_name].zmin != 0 or self.cylinders.processed[neg_cyl_name].zmax != 0:
-                    print(
-                        f"{mt.WARNING} Cannot merge barrel layer {merged_cyc_name}. "
-                        "Layer is not continuous at z=0. Ignoring!"
-                    )
-                    continue
-
-                self.cylinders.processed[pos_cyl_name].zmin = self.cylinders.processed[neg_cyl_name].zmin
-                self.cylinders.processed[merged_cyc_name] = self.cylinders.processed[pos_cyl_name]
-                del self.cylinders.processed[pos_cyl_name]
-                del self.cylinders.processed[neg_cyl_name]
+        # Merge barrel layers continuous at z=0
+        self._merge_barrel()
 
     def check_overlaps(
         self,

--- a/pygeosimplify/simplify/detector.py
+++ b/pygeosimplify/simplify/detector.py
@@ -186,12 +186,13 @@ class SimplifiedDetector:
                 pos_cyl_name = each_cyl_name
                 neg_cyl_name = each_cyl_name.replace("_POS", "_NEG")
                 merged_cyc_name = each_cyl_name.replace("_POS", "")
-                
+
                 # ignore barrel layers which are not continuous at z=0
-                if (self.cylinders.processed[pos_cyl_name].zmin != 0 or
-                    self.cylinders.processed[neg_cyl_name].zmax != 0):
-                    print(f"{mt.WARNING} Cannot merge barrel layer {merged_cyc_name}. "
-                            "Layer is not continuous at z=0. Ignoring!")
+                if self.cylinders.processed[pos_cyl_name].zmin != 0 or self.cylinders.processed[neg_cyl_name].zmax != 0:
+                    print(
+                        f"{mt.WARNING} Cannot merge barrel layer {merged_cyc_name}. "
+                        "Layer is not continuous at z=0. Ignoring!"
+                    )
                     continue
 
                 self.cylinders.processed[pos_cyl_name].zmin = self.cylinders.processed[neg_cyl_name].zmin

--- a/tests/test_simplified_detector.py
+++ b/tests/test_simplified_detector.py
@@ -51,11 +51,11 @@ def test_process(atlas_calo_geo):  # noqa: F811
     detector.process()
 
     assert detector.processed == True
-    assert pytest.approx(detector.cylinders.processed["0_POS"].rmin, abs=1e-3) == 1451.6619
-    assert pytest.approx(detector.cylinders.processed["0_POS"].rmax, abs=1e-3) == 1461.6619
-    assert pytest.approx(detector.cylinders.processed["0_POS"].zmin, abs=1e-3) == 0.0
-    assert pytest.approx(detector.cylinders.processed["0_POS"].zmax, abs=1e-3) == 3663.0
-    assert detector.cylinders.processed["0_POS"].is_barrel == True
+    assert pytest.approx(detector.cylinders.processed["0"].rmin, abs=1e-3) == 1451.6619
+    assert pytest.approx(detector.cylinders.processed["0"].rmax, abs=1e-3) == 1461.6619
+    assert pytest.approx(detector.cylinders.processed["0"].zmin, abs=1e-3) == -3663.0
+    assert pytest.approx(detector.cylinders.processed["0"].zmax, abs=1e-3) == 3663.0
+    assert detector.cylinders.processed["0"].is_barrel == True
 
     assert pytest.approx(detector.cylinders.processed["21_POS"].rmin, abs=1e-3) == 69.9850
     assert pytest.approx(detector.cylinders.processed["21_POS"].rmax, abs=1e-3) == 1703.0514
@@ -68,12 +68,6 @@ def test_process(atlas_calo_geo):  # noqa: F811
     assert pytest.approx(detector.cylinders.processed["4_POS"].zmin, abs=1e-3) == 3667.0
     assert pytest.approx(detector.cylinders.processed["4_POS"].zmax, abs=1e-3) == 3671.0
     assert detector.cylinders.processed["4_POS"].is_barrel == False
-
-    assert pytest.approx(detector.cylinders.processed["0_NEG"].rmin, abs=1e-3) == 1451.6619
-    assert pytest.approx(detector.cylinders.processed["0_NEG"].rmax, abs=1e-3) == 1461.6619
-    assert pytest.approx(detector.cylinders.processed["0_NEG"].zmin, abs=1e-3) == -3663.0
-    assert pytest.approx(detector.cylinders.processed["0_NEG"].zmax, abs=1e-3) == 0.0
-    assert detector.cylinders.processed["0_NEG"].is_barrel == True
 
     assert pytest.approx(detector.cylinders.processed["21_NEG"].rmin, abs=1e-3) == 69.9850194
     assert pytest.approx(detector.cylinders.processed["21_NEG"].rmax, abs=1e-3) == 1703.05139


### PR DESCRIPTION
Add a method in the `detector` class to merge positive parts and negative parts of barrel layers. A merged barrel layer is needed to avoid particles getting stuck in the shared boundary between the positive part and negative part during transportation. 