### PR TITLE
Add py313 support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
 {
 	"name": "pygeosimplify",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	// Full list of images: https://mcr.microsoft.com/v2/devcontainers/python/tags/list
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.13-bullseye",
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/poetry:2": {
 			"version": "2.0.1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     steps:
       - name: Check out

--- a/poetry.lock
+++ b/poetry.lock
@@ -3519,5 +3519,5 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9,<3.13"
-content-hash = "bd67ec4e05949a4ccde38c6d0c3c89dadaad7cb2c55a87d968ac766a743884cb"
+python-versions = ">=3.9,<3.14"
+content-hash = "9c19a4fb25a50f312f23aea85d15d0438892c1c7aaba8e3139ca1ba9e31a860e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ packages = [
   { include = "pygeosimplify" }
 ]
 
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 dynamic = ["dependencies"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.9,<3.14"
 uproot = "^5.1.2"
 pandas = "^2.1.2"
 numpy = "^1.26.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 ]
 
 requires-python = ">=3.9,<3.14"
-dynamic = ["dependencies"]
+dynamic = ["requires-python", "dependencies"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.14"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = py39, py310, py311, py312
+envlist = py39, py310, py311, py312, py313
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 [testenv]
 passenv = PYTHON_VERSION
 allowlist_externals = poetry


### PR DESCRIPTION
This PR adds initial [Python 3.13](https://docs.python.org/3/whatsnew/3.13.html) support. Also changes the devcontainer default accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Development Environment**
	- Updated development container to Python 3.13
	- Added support for Python 3.9-3.13 in project configuration
	- Updated dependency versions for broader compatibility

- **Chores**
	- Modified CI/CD configuration to include Python 3.13 testing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->